### PR TITLE
fix incorrect schema descriptions for alarm and certificate

### DIFF
--- a/aws-lightsail-alarm/aws-lightsail-alarm.json
+++ b/aws-lightsail-alarm/aws-lightsail-alarm.json
@@ -9,7 +9,7 @@
             "pattern": "\\w[\\w\\-]*\\w"
         },
         "MonitoredResourceName": {
-            "description": "The validation status of the SSL/TLS certificate.",
+            "description": "The name of the Lightsail resource that the alarm monitors.",
             "type": "string"
         },
         "MetricName": {

--- a/aws-lightsail-certificate/aws-lightsail-certificate.json
+++ b/aws-lightsail-certificate/aws-lightsail-certificate.json
@@ -1,6 +1,6 @@
 {
     "typeName": "AWS::Lightsail::Certificate",
-    "description": "An example resource schema demonstrating some basic constructs and validation rules.",
+    "description": "Resource Type definition for AWS::Lightsail::Certificate.",
     "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git",
     "definitions": {
         "Tag": {


### PR DESCRIPTION
*Issue #, if available:*
Alarm: https://github.com/hashicorp/terraform-provider-awscc/issues/1821
Certificate: https://github.com/hashicorp/terraform-provider-awscc/issues/1820


*Description of changes:*
Fix incorrect schema description for alarm and certificate resource types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
